### PR TITLE
兼容新版 mirai-api-http 的临时信息/图片发送

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,20 +190,32 @@ class NodeMirai {
    * @description 发送临时消息
    * @async
    * @param { MessageChain[] } MessageChain MessageChain 数组
-   * @param { number } target long int 高32位为临时会话群号，低32位为临时会话对象QQ号
+   * @param { number } qq 临时消息发送对象 QQ 号
+   * @param { number } group 所在群号
    * @return { object } {
    *  code: 0,
    *  msg: "success",
    *  messageId: 123456
    * }
    */
-  async sendTempMessage (message, target) {
-    return sendTempMessage({
-      messageChain: message,
-      target,
-      sessionKey: this.sessionKey,
-      host: this.host,
-    });
+  async sendTempMessage (message, qq, group) {
+    // 兼容旧格式：高 32 位为群号，低 32 位为 QQ 号
+    if (!group)
+      return sendTempMessage({
+        messageChain: message,
+        qq: (qq & 0xFFFFFFFF),
+        group: ((qq >> 32) & 0xFFFFFFFF),
+        sessionKey: this.sessionKey,
+        host: this.host,
+      });
+    else
+      return sendTempMessage({
+        messageChain: message,
+        qq,
+        group,
+        sessionKey: this.sessionKey,
+        host: this.host,
+      });
   }
   /**
    * @method NodeMirai#sendImageMessage
@@ -321,6 +333,7 @@ class NodeMirai {
    * @async
    * @param { MessageChain[] } MessageChain MessageChain 数组
    * @param { number } qq 发送对象的 qq 号
+   * @param { number } group 发送对象的群号
    * @param { number } quote 引用的 Message 的 id
    * @return { object } {
    *  code: 0,
@@ -328,10 +341,12 @@ class NodeMirai {
    *  messageId: 123456
    * }
    */
-  async sendQuotedFriendMessage (message, target, quote) {
+  async sendQuotedFriendMessage (message, qq, group, quote) {
     return sendQuotedFriendMessage({
       messageChain: message,
-      target, quote,
+      qq,
+      group,
+      quote,
       sessionKey: this.sessionKey,
       host: this.host,
     });

--- a/index.js
+++ b/index.js
@@ -298,6 +298,9 @@ class NodeMirai {
       case 'GroupMessage':
         type = 'group';
         break;
+      case 'TempMessage':
+        type = 'temp';
+        break;
       default:
         console.error('Error @ uploadImage: unknown target type');
     }
@@ -389,14 +392,26 @@ class NodeMirai {
    * }
    */
   async sendQuotedTempMessage (message, qq, group, quote) {
-    return sendQuotedTempMessage({
-      messageChain: message,
-      qq,
-      group,
-      quote,
-      sessionKey: this.sessionKey,
-      host: this.host,
-    });
+    // 兼容旧格式：高 32 位为群号，低 32 位为 QQ 号
+    // 若使用旧 API 格式，则 group 位置的值实为 quote
+    if (!quote)
+      return sendQuotedTempMessage({
+        messageChain: message,
+        qq: (qq & 0xFFFFFFFF),
+        group: ((qq >> 32) & 0xFFFFFFFF),
+        quote: group,
+        sessionKey: this.sessionKey,
+        host: this.host,
+      });    
+    else
+      return sendQuotedTempMessage({
+        messageChain: message,
+        qq,
+        group,
+        quote,
+        sessionKey: this.sessionKey,
+        host: this.host,
+      });
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -322,6 +322,8 @@ class NodeMirai {
         return this.sendFriendMessage(message, target.sender.id);
       case 'GroupMessage':
         return this.sendGroupMessage(message, target.sender.group.id);
+      case 'TempMessage':
+        return this.sendTempMessage(message, target.sender.id, target.sender.group,id);
       default:
         console.error('Invalid target @ sendMessage');
     }
@@ -411,6 +413,8 @@ class NodeMirai {
           return await this.sendQuotedFriendMessage(message, target.sender.id, quote);
         case 'GroupMessage':
           return await this.sendQuotedGroupMessage(message, target.sender.group.id, quote);
+        case 'TempMessage':
+          return await this.sendQuotedTempMessage(message, target.sender.id, target.sender.group.id, quote);
         default:
           console.error('Invalid target @ sendQuotedMessage');
           // process.exit(1);

--- a/index.js
+++ b/index.js
@@ -379,7 +379,8 @@ class NodeMirai {
    * @description 发送带引用的临时消息
    * @async
    * @param { MessageChain[] } MessageChain MessageChain 数组
-   * @param { number } target long int 高32位为临时会话群号，低32位为临时会话对象QQ号
+   * @param { number } qq 临时消息发送对象 QQ 号
+   * @param { number } group 所在群号
    * @param { number} quote 引用的 Message 的 id
    * @return { object } {
    *  code: 0,
@@ -387,10 +388,12 @@ class NodeMirai {
    *  messageId: 123456
    * }
    */
-  async sendQuotedTempMessage (message, target, quote) {
+  async sendQuotedTempMessage (message, qq, group, quote) {
     return sendQuotedTempMessage({
       messageChain: message,
-      target, quote,
+      qq,
+      group,
+      quote,
       sessionKey: this.sessionKey,
       host: this.host,
     });

--- a/src/group.js
+++ b/src/group.js
@@ -151,7 +151,6 @@ const handleMemberJoinRequest = async({
   operate,
   message
 }) => {
-  console.log(sessionKey, eventId, fromId, groupId, operate, message)
   const { data } = await axios.post(`${host}/resp/memberJoinRequestEvent`, {
     sessionKey,
     eventId,

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -67,13 +67,14 @@ const sendQuotedGroupMessage = async ({
 
 const sendTempMessage = async ({
   messageChain,
-  target,
+  qq,
+  group,
   sessionKey,
   host = 8080,
 }) => {
   if (typeof messageChain === 'string') messageChain = [Plain(messageChain)];
   const { data } = await axios.post(`${host}/sendTempMessage`, {
-    messageChain, target, sessionKey,
+    messageChain, qq, group, sessionKey,
   }).catch(e => {
     console.error('Unknown Error @ sendTempMessage:', e.message);
   });
@@ -81,14 +82,15 @@ const sendTempMessage = async ({
 };
 const sendQuotedTempMessage = async ({
   messageChain,
-  target,
+  qq,
+  group,
   quote,
   sessionKey,
   host = 8080,
 }) => {
   if (typeof messageChain === 'string') messageChain = [Plain(messageChain)];
   const { data } = await axios.post(`${host}/sendTempMessage`, {
-    messageChain, target, sessionKey, quote,
+    messageChain, qq, group, sessionKey, quote,
   }).catch(e => {
     console.error('Unknown Error @ sendQuotedTempMessage:', e.message);
   });


### PR DESCRIPTION
`mirai-api-http v1.6.2` 起对临时信息 (`/sendTempMessage`) 接口进行了参数调整，现有版本无法通过内置的 `bot.sendTempMessage` 和 `bot.sendQuotedTempMessage` 发送临时信息。

函数改动：

- 调整 `sendTempMessage, sendQuotedTempMessage` 的参数
- 为 `sendMessage` 和 `uploadImage` 添加 `TempMessage` 类型检测

API 改动（均为兼容旧版写法的更新）：

- `bot.sendTempMessage(message, target)` => `bot.sendTempMessage(message, qq, group)`
- `bot.sendQuotedTempMessage(message, target, quote)` => `bot.sendQuotedTempMessage(message, qq, group, quote)`

另外如果方便的话，建议更新一下 API 参考文档，像 `sendTempMessage` 及衍生方法的参数，那份文档里都没有提到。