### PR TITLE
修复了 WebSocket 链接被忽略的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ jsdoc*
 docs/
 
 .idea
+
+.vscode

--- a/index.js
+++ b/index.js
@@ -901,9 +901,22 @@ class NodeMirai {
     if (this.enableWebsocket) {
       this.onSignal('verified', () => {
         const wsHost = `${this.host.replace('http', 'ws')}/all?sessionKey=${this.sessionKey}`;
-        (new WebSocket(wsHost)).on('message', message => {
+        const ws = new WebSocket(wsHost);
+        ws.on('message', message => {
           this.emitEventListener(JSON.parse(message));
-        })
+        });
+        ws.on('open',() => {
+          const interval = setInterval(() => {
+            ws.ping((err) => {
+              if (err) {
+                // todo sth.
+              }
+            });
+          }, 60000);
+          ws.on('close',(code, reason) => {
+            clearInterval(interval);
+          });
+        });
       });
     }
     else setInterval(async () => {


### PR DESCRIPTION
若没有任何事件发生，服务端将会在几分钟内忽略该 WebSocket 连接。

忽略指该连接没有发生 error close 等事件，状态仍然是 OPEN，但不会收到任何消息。

经过测试，定时向服务端发送 ping 包将会维持该连接。