### PR TITLE
Implement new features in mirai-api-http v1.11.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ const {
 
 const group = require('./src/group');
 
+const {
+  uploadFileAndSend
+} = require('./src/fileUtility');
+
 /**
  * @typedef { Object } MessageChain 消息链
  * @description 消息链对象, node-mirai-sdk 提供各类型的 .value() 方法获得各自的属性值
@@ -298,7 +302,7 @@ class NodeMirai {
   /**
    * @method NodeMirai#sendFlashImageMessage
    * @async
-   * @param { url } url 图片所在路径
+   * @param { string | Buffer | ReadStream } url 图片所在路径
    * @param { message } target 发送目标对象
    * @return { object } {
    *  code: 0,
@@ -818,6 +822,24 @@ class NodeMirai {
       message,
       host: this.host,
       sessionKey: this.sessionKey,
+    });
+  }
+
+  /**
+   * @method NodeMirai#uploadFileAndSend
+   * @description 上传（群）文件并发送
+   * @param { string | Buffer | ReadStream } url 文件所在路径或 URL
+   * @param { string } path 文件要上传到群文件中的位置（路径）
+   * @param { message } target 要发送文件的目标
+   */
+  uploadFileAndSend(url, path, target) {
+    const { sessionKey, host } = this;
+    return uploadFileAndSend({
+      url,
+      path,
+      target,
+      sessionKey,
+      host
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ const {
   sendQuotedGroupMessage,
   sendQuotedTempMessage,
   uploadImage,
+  uploadVoice,
   sendImageMessage,
+  sendVoiceMessage,
   sendFlashImageMessage
 } = require('./src/sendMessage');
 
@@ -271,6 +273,29 @@ class NodeMirai {
     }
   }
   /**
+   * @method NodeMirai#sendVoiceMessage
+   * @async
+   * @param { string | Buffer | ReadStream } url 语音所在路径
+   * @param { target } group 发送目标对象（目前仅支持群组）
+   * @return { object } {
+   *  code: 0,
+   *  msg: "success",
+   *  messageId: 123456
+   * }
+   */
+  async sendVoiceMessage (url, target) {
+    if (target.type !== 'GroupMessage')
+      console.error('Error @ sendVoiceMessage: only support send voice to group');
+
+    return sendVoiceMessage({
+      url,
+      group: target.sender.group.id,
+      sessionKey: this.sessionKey,
+      host: this.host
+    });
+  }
+
+  /**
    * @method NodeMirai#sendFlashImageMessage
    * @async
    * @param { url } url 图片所在路径
@@ -334,6 +359,25 @@ class NodeMirai {
     });
   }
 
+
+  /**
+   * @method NodeMirai#uploadVoice
+   * @async
+   * @param { string | Buffer | ReadStream } url 声音所在路径
+   * @returns { object } {
+   *  voiceId: "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.amr",
+   *  url: "xxxxxxxxxxxxxxxxxxxx"
+   * }
+   */
+  async uploadVoice (url) {
+    return uploadVoice({
+      url,
+      type: 'group',
+      sessionKey: this.sessionKey,
+      host: this.host
+    });
+  }
+
   /**
    * @method NodeMirai#sendMessage
    * @description 发送消息给指定好友或群组
@@ -348,7 +392,7 @@ class NodeMirai {
       case 'GroupMessage':
         return this.sendGroupMessage(message, target.sender.group.id);
       case 'TempMessage':
-        return this.sendTempMessage(message, target.sender.id, target.sender.group,id);
+        return this.sendTempMessage(message, target.sender.id, target.sender.group.id);
       default:
         console.error('Invalid target @ sendMessage');
     }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@ const {
 const group = require('./src/group');
 
 const {
-  uploadFileAndSend
+  uploadFileAndSend,
+  getGroupFileList,
+  getGroupFileInfo,
+  renameGroupFile,
+  moveGroupFile,
+  deleteGroupFile
 } = require('./src/fileUtility');
 
 /**
@@ -834,10 +839,117 @@ class NodeMirai {
    */
   uploadFileAndSend(url, path, target) {
     const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
     return uploadFileAndSend({
       url,
       path,
-      target,
+      target: realTarget,
+      sessionKey,
+      host
+    });
+  }
+
+  
+  /**
+   * @method NodeMirai#getGroupFileList
+   * @description 获取群文件指定路径下的文件列表
+   * @param { string } dir 要获取的群文件路径
+   * @param { number | string | message } target 要获取的群号
+   * @returns { object }
+   */
+  getGroupFileList(dir, target) {
+    const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return getGroupFileList({
+      target: realTarget,
+      dir,
+      sessionKey,
+      host
+    });
+  }
+
+  /**
+   * @method NodeMirai#getGroupFileInfo
+   * @description 获取群文件指定详细信息
+   * @param { string } id 文件唯一 ID
+   * @param { number | string | message } target 要获取的群号
+  * @returns { object }
+   */
+  getGroupFileInfo(id, target) {
+    const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return getGroupFileInfo({
+      target: realTarget,
+      id,
+      sessionKey,
+      host
+    });
+  }
+
+  /**
+   * @method NodeMirai#renameGroupFile
+   * @description 重命名指定群文件
+   * @param { string } id 要重命名的文件唯一 ID 
+   * @param { string } rename 文件的新名称
+   * @param { number | string } target 目标群号
+   * @returns { object }
+   */
+  renameGroupFile(id, rename, target) {
+    const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return renameGroupFile({
+      target: realTarget,
+      id,
+      rename,
+      sessionKey,
+      host
+    });
+  }
+
+  /**
+   * @method NodeMirai#moveGroupFile
+   * @description 移动指定群文件
+   * @param { string } id 要移动的文件唯一 ID 
+   * @param { string } movePath 文件的新路径
+   * @param { number | string } target 目标群号
+   * @returns { object }
+   */
+  moveGroupFile(id, movePath, target) {
+    const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return moveGroupFile({
+      target: realTarget,
+      id,
+      movePath,
+      sessionKey,
+      host
+    });
+  }
+
+  /**
+   * 删除指定群文件
+   * @param { string } id 要删除的文件唯一 ID
+   * @param { number | string } target 目标群号
+   * @returns { object }
+   */
+  deleteGroupFile(id, target) {
+    const { sessionKey, host } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return deleteGroupFile({
+      target: realTarget,
+      id,
       sessionKey,
       host
     });

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const WebSocket = require('ws');
 const Signal = require('./src/utils/Signal');
 
 const MessageComponent = require('./src/MessageComponent');
-const { Plain } = MessageComponent;
+const Target = require('./src/target');
 const events = require('./src/events.json');
+
+const { Plain } = MessageComponent;
 
 const init = require('./src/init');
 const verify = require('./src/verify');
@@ -707,6 +709,24 @@ class NodeMirai {
     });
   }
   /**
+   * @method NodeMirai#setEssence
+   * @description 设置群精华消息
+   * @param { number | string | message } target 要设置的群
+   * @param { number } id 精华消息 ID
+   */
+  setEssence(target, id) {
+    const { host, sessionKey } = this;
+    const realTarget = (typeof target === 'number') || (typeof target === 'string')
+      ? target
+      : target.sender.group.id;
+    return group.setEssence({
+      target: realTarget,
+      id,
+      host,
+      sessionKey
+    });
+  }
+  /**
    * @method NodeMirai#getGroupConfig
    * @description 获取群设置
    * @async
@@ -1151,5 +1171,6 @@ class NodeMirai {
 }
 
 NodeMirai.MessageComponent = MessageComponent;
+NodeMirai.Target = Target;
 
 module.exports = NodeMirai;

--- a/index.js
+++ b/index.js
@@ -877,7 +877,7 @@ class NodeMirai {
    * @description 获取群文件指定详细信息
    * @param { string } id 文件唯一 ID
    * @param { number | string | message } target 要获取的群号
-  * @returns { object }
+   * @returns { object }
    */
   getGroupFileInfo(id, target) {
     const { sessionKey, host } = this;

--- a/src/MessageComponent.js
+++ b/src/MessageComponent.js
@@ -150,7 +150,6 @@ const toMiraiCode = component => {
       return `[mirai:face:${component.id}]`;
     case 'Poke':
       return `[mirai:poke:${component.name},${component.type},${component.id}]`;
-      break;
     case 'VipFace':
       // TODO: 当前版本(http-api1.7.2)尚未支持 VipFace 消息
       // return `[mirai:vipface:${component.id},${component.name},${component.count}]`;

--- a/src/MessageComponent.js
+++ b/src/MessageComponent.js
@@ -122,6 +122,20 @@ const Poke = name => {
 };
 Poke.value = poke => poke.name;
 
+const Voice = ({ voiceId, url = '' }) => {
+  return {
+    type: 'Voice',
+    voiceId,
+    url
+  };
+};
+Voice.value = voice => {
+  return {
+    voiceId: voice.voiceId,
+    url: voice.url
+  }
+};
+
 // Experimental
 // refer: https://github.com/mamoe/mirai/blob/master/docs/mirai-code-specification.md
 const toMiraiCode = component => {
@@ -135,8 +149,7 @@ const toMiraiCode = component => {
     case 'Face':
       return `[mirai:face:${component.id}]`;
     case 'Poke':
-      // TODO: 当前版本(mirai-core1.0.2/http-api1.7.2)尚未支持接收 Poke 消息
-      // return `[mirai:poke:${component.name},${component.type},${component.id}]`;
+      return `[mirai:poke:${component.name},${component.type},${component.id}]`;
       break;
     case 'VipFace':
       // TODO: 当前版本(http-api1.7.2)尚未支持 VipFace 消息
@@ -144,6 +157,8 @@ const toMiraiCode = component => {
       break;
     case 'Image':
       return `[mirai:image:${component.imageId}]`;
+    case 'Voice':
+      return `[mirai:voice:${component.voiceId}]`;
     case 'FlashImage':
       return `[mirai:flash:${component.imageId}]`;
   }
@@ -166,6 +181,7 @@ module.exports = {
   App,
   Quote,
   Poke,
+  Voice,
   toMiraiCode,
   parseMiraiCode,
 };

--- a/src/fileUtility.js
+++ b/src/fileUtility.js
@@ -8,7 +8,7 @@ const FormData = require("form-data");
  * 上传群文件并发送
  * @param { string | Buffer | ReadStream } url 文件所在路径或 URL
  * @param { string } path 文件要上传到群文件中的位置（路径）
- * @param { message } target 要发送文件的目标
+ * @param { string } target 要发送文件的目标
  * @param { string } sessionKey
  * @param { string } host
  * @return { object } 
@@ -35,6 +35,133 @@ const uploadFileAndSend = async({
   return data;
 };
 
+/**
+ * 获取群文件指定路径下的文件列表
+ * @param { number | string } target 要获取的群号
+ * @param { string } dir 要获取的群文件路径
+ * @param { string } sessionKey
+ * @param { string } host
+ * @returns { object }
+ */
+const getGroupFileList = async({
+  target,
+  dir,
+  sessoinKey,
+  host 
+}) => {
+  const encodedDir = (dir === undefined) ? "/" : encodeURIComponent(dir);
+  const { data } = await axios.get(`${host}/groupFileList?sessionKey=${sessoinKey}&target=${target}&dir=${encodedDir}`);
+  return data;
+};
+
+/**
+ * 获取群文件指定详细信息
+ * @param { number | string } target 要获取的群号
+ * @param { string } id 文件唯一 ID 
+ * @param { string } sessionKey
+ * @param { string } host
+ * @returns { object }
+ */
+const getGroupFileInfo = async({
+  target,
+  id,
+  sessionKey,
+  host
+}) => {
+  const { data } = await axios.get(`${host}/groupFileInfo?sessionKey=${sessionKey}&target=${target}&id=${id}`);
+  return data;
+};
+
+
+/**
+ * 重命名指定群文件
+ * @param { number | string } target 目标群号
+ * @param { string } id 要重命名的文件唯一 ID 
+ * @param { string } rename 文件的新名称
+ * @param { string } sessionKey
+ * @param { string } host
+ * @returns { object }
+ */
+const renameGroupFile = async({
+  target,
+  id,
+  rename,
+  sessionKey,
+  host
+}) => {
+  const form = new FormData();
+  form.append('sessionKey', sessionKey);
+  form.append('target', target);
+  form.append('id', id);
+  form.append('rename', rename);
+
+  const { data } = await axios.post(`${host}/groupFileRename`, form, {
+    headers: form.getHeaders()
+  });
+
+  return data;
+};
+
+/**
+ * 移动指定群文件
+ * @param { number | string } target 目标群号
+ * @param { string } id 要移动的文件唯一 ID 
+ * @param { string } movePath 文件的新路径
+ * @param { string } sessionKey
+ * @param { string } host
+ * @returns { object }
+ */
+const moveGroupFile = async({
+  target,
+  id,
+  movePath,
+  sessionKey,
+  host
+}) => {
+  const form = new FormData();
+  form.append('sessionKey', sessionKey);
+  form.append('id', id);
+  form.append('target', target);
+  form.append('movePath', movePath);
+
+  const { data } = await axios.post(`${host}/groupFileMove`, form, {
+    headers: form.getHeaders()
+  });
+
+  return data;
+};
+
+/**
+ * 删除指定群文件
+ * @param { number | string } target 目标群号
+ * @param { string } id 要删除的文件唯一 ID
+ * @param { string } sessionKey
+ * @param { string } host
+ * @returns { object }
+ */
+const deleteGroupFile = async({
+  target,
+  id,
+  sessionKey,
+  host
+}) => {
+  const form = new FormData();
+  form.append('sessionKey', sessionKey);
+  form.append('id', id);
+  form.append('target', target);
+
+  const { data } = await axios.post(`${host}/groupFileDelete`, form, {
+    headers: form.getHeaders()
+  });
+
+  return data;
+};
+
 module.exports = { 
-  uploadFileAndSend
+  uploadFileAndSend,
+  getGroupFileList,
+  getGroupFileInfo,
+  renameGroupFile,
+  moveGroupFile,
+  deleteGroupFile
 };

--- a/src/fileUtility.js
+++ b/src/fileUtility.js
@@ -1,0 +1,40 @@
+// node-mirai 文件发送 & 群文件管理相关实现
+
+const fs = require("fs");
+const axios = require("axios");
+const FormData = require("form-data");
+
+/**
+ * 上传群文件并发送
+ * @param { string | Buffer | ReadStream } url 文件所在路径或 URL
+ * @param { string } path 文件要上传到群文件中的位置（路径）
+ * @param { message } target 要发送文件的目标
+ * @param { string } sessionKey
+ * @param { string } host
+ * @return { object } 
+ */
+const uploadFileAndSend = async({
+  url,
+  path,
+  target,
+  sessionKey,
+  host
+}) => {
+  const file = (typeof url === "string") ? fs.createReadStream(url) : url,
+    form = new FormData();
+  form.append('sessionKey', sessionKey);
+  form.append('type', "Group");               // 当前只支持上传群文件
+  form.append('path', path);
+  form.append('target', target);
+  form.append('file', file);
+
+  const { data } = await axios.post(`${host}/uploadFileAndSend`, form, {
+    headers: form.getHeaders()
+  });
+
+  return data;
+};
+
+module.exports = { 
+  uploadFileAndSend
+};

--- a/src/fileUtility.js
+++ b/src/fileUtility.js
@@ -49,8 +49,10 @@ const getGroupFileList = async({
   sessoinKey,
   host 
 }) => {
-  const encodedDir = (dir === undefined) ? "/" : encodeURIComponent(dir);
-  const { data } = await axios.get(`${host}/groupFileList?sessionKey=${sessoinKey}&target=${target}&dir=${encodedDir}`);
+  let getUrl = `${host}/groupFileList?sessionKey=${sessionKey}&target=${target}`;
+  if (dir !== undefined)
+    getUrl += `&dir=${encodeURIComponent(dir)}`;
+  const { data } = await axios.get(getUrl);
   return data;
 };
 
@@ -89,14 +91,11 @@ const renameGroupFile = async({
   sessionKey,
   host
 }) => {
-  const form = new FormData();
-  form.append('sessionKey', sessionKey);
-  form.append('target', target);
-  form.append('id', id);
-  form.append('rename', rename);
-
-  const { data } = await axios.post(`${host}/groupFileRename`, form, {
-    headers: form.getHeaders()
+  const { data } = await axios.post(`${host}/groupFileRename`, {
+    sessionKey,
+    target,
+    id,
+    rename
   });
 
   return data;
@@ -118,14 +117,11 @@ const moveGroupFile = async({
   sessionKey,
   host
 }) => {
-  const form = new FormData();
-  form.append('sessionKey', sessionKey);
-  form.append('id', id);
-  form.append('target', target);
-  form.append('movePath', movePath);
-
-  const { data } = await axios.post(`${host}/groupFileMove`, form, {
-    headers: form.getHeaders()
+  const { data } = await axios.post(`${host}/groupFileMove`, {
+    sessionKey,
+    id,
+    target,
+    movePath
   });
 
   return data;
@@ -145,13 +141,10 @@ const deleteGroupFile = async({
   sessionKey,
   host
 }) => {
-  const form = new FormData();
-  form.append('sessionKey', sessionKey);
-  form.append('id', id);
-  form.append('target', target);
-
-  const { data } = await axios.post(`${host}/groupFileDelete`, form, {
-    headers: form.getHeaders()
+  const { data } = await axios.post(`${host}/groupFileDelete`, {
+    sessionKey,
+    id,
+    target
   });
 
   return data;

--- a/src/group.js
+++ b/src/group.js
@@ -67,7 +67,7 @@ const setUnmuteAll = async ({ //群解除全体禁言
   return { data };
 };
 
-const setKick = async ({ //移除群成员
+const setKick = async ({ // 移除群成员
   target,
   memberId,
   msg,
@@ -83,7 +83,18 @@ const setKick = async ({ //移除群成员
   return data;
 }
 
-const getConfig = async ({ //获取群设置
+const setEssence = async ({  // 设置群精华
+  target,
+  sessionKey
+}) => {
+  const { data } = await axios.post(`${host}/setEssence`, {
+    sessionKey,
+    target
+  });
+  return data;
+}
+
+const getConfig = async ({ // 获取群设置
   target,
   host,
   sessionKey,
@@ -169,6 +180,7 @@ module.exports = {
   setMuteAll,
   setUnmuteAll,
   setKick,
+  setEssence,
   getConfig,
   setConfig,
   getMemberInfo,

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const fs = require('fs');
 const FormData = require('form-data');
 
-const { Plain, Image, FlashImage } = require('./MessageComponent');
+const { Plain, Image, FlashImage, Voice } = require('./MessageComponent');
 
 const sendFriendMessage = async ({ //发送好友消息
   messageChain,
@@ -118,6 +118,24 @@ const uploadImage = async ({
   return data;
 };
 
+const uploadVoice = async({
+  url,
+  type,
+  sessionKey,
+  host
+}) => {
+  let voice = (typeof url === 'string') ? fs.createReadStream(url) : url;
+  const form = new FormData();
+  form.append('sessionKey', sessionKey);
+  form.append('type', type);
+  form.append('voice', voice);
+
+  const { data } = await axios.post(`${host}/uploadVoice`, form, {
+    headers: form.getHeaders()
+  });
+  return data;
+};
+
 const sendImageMessage = async ({
   url,
   qq,
@@ -147,6 +165,29 @@ const sendImageMessage = async ({
     target,
     sessionKey,
     host,
+  });
+};
+
+const sendVoiceMessage = async({
+  url,
+  group,
+  sessionKey,
+  host = 8080
+}) => {
+  const target = group,
+    type = 'group';
+  const voice = await uploadVoice({
+    url,
+    type,
+    sessionKey,
+    host
+  });
+  const messageChain = [Voice(voice)];
+  return sendGroupMessage({
+    messageChain,
+    target,
+    sessionKey,
+    host
   });
 };
 
@@ -190,6 +231,8 @@ module.exports = {
   sendTempMessage,
   sendQuotedTempMessage,
   uploadImage,
+  uploadVoice,
   sendImageMessage,
+  sendVoiceMessage,
   sendFlashImageMessage,
 };

--- a/src/target.js
+++ b/src/target.js
@@ -1,0 +1,31 @@
+const Friend = (qq) => ({
+  type: 'FriendMessage',
+  sender: {
+    id: qq
+  }
+});
+
+const Group = (groupId) => ({
+  type: 'GroupMessage',
+  sender: {
+    group: {
+      id: groupId
+    }
+  }
+});
+
+const Temp = (groupId, qq) => ({
+  type: 'TempMessage',
+  sender: {
+    id: qq,
+    group: {
+      id: groupId
+    }
+  }
+});
+
+module.exports = {
+  Friend,
+  Group,
+  Temp
+};


### PR DESCRIPTION
## 语音发送/上传接口

- `bot.sendVoiceMessage(url, target)`  发送语音
- `bot.uploadVoice(url)` 上传语音

支持通过 mirai-api-http 发送语音（需要自行转换成 `amr` 格式或 `silk v3` 格式）。需要注意的是，目前 mirai 的语音发送功能仍然不是很完善。

## 群文件上传、获取、管理接口

- `bot.uploadFileAndSend(url, path, target)` 上传群文件
- `bot.getGroupFileList(dir, target)` 获取指定群、指定路径的群文件列表
- `bot.getGroupFileInfo(id, target)` 获取指定群文件的信息
- `bot.renameGroupFile(id, rename, target)` 重命名群文件
- `bot.moveGroupFile(id, movePath, target)` 移动群文件
- `bot.deleteGroupFile(id, target)` 删除群文件

## 设置群精华

- `bot.setEssence(target, id)` 设置群精华消息

## `target` 构造

先前的版本主动调用部分接口，需要按照消息的格式，构造发送对象 `target`：

```js
// 私聊发送图片给 12345678
bot.sendImageMessage(url, { type: 'FriendMessage', sender: { id: 12345678 } });
// 群聊发送图片到 998244353
bot.sendImageMessage(url, { type: 'FriendMessage', sender: { group:  { id: 998244353 } } });
```

通过从 `NodeMirai.Target` 引入 `Friend, Group` 或 `Temp` 可以省去构造 target 的过程：

```js
const { Friend, Group, Temp } = require("node-mirai-sdk").Target;
bot.sendImageMessage(url, Friend(12345678));
bot.sendImageMessage(url, Group(998244353));
bot.sendImageMessage(url, Temp(998244353, 12345678));               // 给群号为 998244353 的用户 12345678 发送临时消息图片
```

另外有两件事很抱歉，第一是先前误发起了一个反向 PR，第二是新系统忘记配置关闭 CRLF 转换导致提交的时候 diff 太多了……