### PR TITLE
修复Image的类型bug

### DIFF
--- a/src/MessageComponent.js
+++ b/src/MessageComponent.js
@@ -11,7 +11,7 @@
  * @property { string } [display]
  * 
  * @typedef { Object } image
- * @property { string } imageId
+ * @property { string } [imageId]
  * @property { string } [url]
  * 
  * @typedef { Object } voice


### PR DESCRIPTION
imageId似乎不是必要的填写信息，如果用户使用Image时不填写imageId则会报错，故使其可选